### PR TITLE
Deploy extra dirs before files for ensuring dir creation

### DIFF
--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -160,24 +160,13 @@ def deploy_files(config_file, plugin_path, confirm=True, quick=False):
 
 def install_files(plugin_dir, cfg):
     errors = []
-    install_files = get_install_files(cfg)
     # make the plugin directory if it doesn't exist
     if not os.path.exists(plugin_dir):
         os.makedirs(plugin_dir)
 
     fail = False
-    for file in install_files:
-        click.secho("Copying {0}".format(file), fg='magenta', nl=False)
-        try:
-            shutil.copy(file, os.path.join(plugin_dir, file))
-            print ""
-        except Exception as oops:
-            errors.append(
-                "Error copying files: {0}, {1}".format(file, oops.strerror))
-            click.echo(click.style(' ----> ERROR', fg='red'))
-            fail = True
-        extra_dirs = cfg.get('files', 'extra_dirs').split()
-        # print "EXTRA DIRS: {}".format(extra_dirs)
+    extra_dirs = cfg.get('files', 'extra_dirs').split()
+    # print "EXTRA DIRS: {}".format(extra_dirs)
     for xdir in extra_dirs:
         click.secho("Copying contents of {0} to {1}".format(xdir, plugin_dir),
                     fg='magenta',
@@ -188,6 +177,17 @@ def install_files(plugin_dir, cfg):
         except Exception as oops:
             errors.append(
                 "Error copying directory: {0}, {1}".format(xdir, oops.message))
+            click.echo(click.style(' ----> ERROR', fg='red'))
+            fail = True
+    install_files = get_install_files(cfg)
+    for file in install_files:
+        click.secho("Copying {0}".format(file), fg='magenta', nl=False)
+        try:
+            shutil.copy(file, os.path.join(plugin_dir, file))
+            print ""
+        except Exception as oops:
+            errors.append(
+                "Error copying files: {0}, {1}".format(file, oops.strerror))
             click.echo(click.style(' ----> ERROR', fg='red'))
             fail = True
     help_src = cfg.get('help', 'dir')


### PR DESCRIPTION
When an Qt .ui file is in a subfolder, an error occurs on `pb_tool deploy` because the distant directory is not created.
Part of QGIS 3.x plugin's `pb_tool.cfg` file :

```
[...]
# Other ui files for dialogs you create (these will be compiled)
compiled_ui_files: ui/my_second_dialog.ui
[...]
# Other directories to be deployed with the plugin.
# These must be subdirectories under the plugin directory
extra_dirs: ui
```

With the actual pb_tool version, an error occurs during deployment :
```sh
Copying ui/my_second_dialog.py ----> ERROR
Copying resources.py
Copying metadata.txt
Copying icon.png
Copying contents of ui to /home/me/.local/share/QGIS/QGIS3/profiles/default/python/plugins/my_plugin
Copying help/build/html to /home/me/.local/share/QGIS/QGIS3/profiles/default/python/plugins/my_plugin/help

ERRORS:
Error copying files: ui/my_second_dialog.py, No such file or directory
```

The modification I've made is to deploy extra directories before files to avoid this error.
The Qt .ui file will be deployed with its compiled version.