### PR TITLE
Allow files from sub dirs in install_files(..)

### DIFF
--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -181,7 +181,9 @@ def install_files(plugin_dir, cfg):
     for file in install_files:
         click.secho("Copying {0}".format(file), fg='magenta', nl=False)
         try:
-            shutil.copy(file, os.path.join(plugin_dir, file))
+            dest_file = os.path.join(plugin_dir, file)
+            os.makedirs(os.path.dirname(dest_file), exist_ok=True)
+            shutil.copy(file, dest_file)
             print("")
         except Exception as oops:
             errors.append(


### PR DESCRIPTION
It would be nice to allow files from sub dirs in install_files(..)