### PR TITLE
update qgis2 plugin path to qgis3

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Commands:
   clean-docs  Remove the built HTML help files from the build directory
   compile     Compile the resource and ui files
   config      Create a config file based on source files in the current...
-  dclean      Remove the deployed plugin from the .qgis2/python/plugins...
+  dclean      Remove the deployed plugin from the ~/(UserProfile)/python/plugins...
   deploy      Deploy the plugin to QGIS plugin directory using parameters
               in...
   doc         Build HTML version of the help files using sphinx
@@ -134,7 +134,7 @@ Options:
   $ pb_tool dclean --help
   Usage: pb_tool dclean [OPTIONS]
 
-    Remove the deployed plugin from the .qgis2/python/plugins directory
+    Remove the deployed plugin from the ~/(UserProfile)/python/plugins directory
 
   Options:
     --config TEXT  Name of the config file to use if other than pb_tool.cfg
@@ -222,7 +222,7 @@ and should be self-explanatory.
 
 [plugin]
 # Name of the plugin. This is the name of the directory that will
-# be created in .qgis2/python/plugins
+# be created in ~/(UserProfile)/python/plugins
 name: TestPlugin
 
 [files]
@@ -260,7 +260,7 @@ target: help
 
 ```shell
 Use ``pb_tool deploy`` to build your plugin and copy it
-to qgis2/python/plugins`` in your HOME directory:
+to ~/<UserProfiles>/QGIS/QGIS3/profiles/default/python/plugins`` in your HOME directory:
 
 
 pb_tool deploy
@@ -268,11 +268,11 @@ Deploying will:
             * Remove your currently deployed version
             * Compile the ui and resource files
             * Build the help docs
-            * Copy everything to your .qgis2/python/plugins directory
+            * Copy everything to your ~/(UserProfile)/python/plugins directory
 
 Proceed? [y/N]: y
-Removing plugin from /Users/gsherman/.qgis2/python/plugins/TestPlugin
-Deploying to /Users/gsherman/.qgis2/python/plugins/TestPlugin
+Removing plugin from /Users/gsherman/~/(UserProfile)/python/plugins/TestPlugin
+Deploying to /Users/gsherman/~/(UserProfile)/python/plugins/TestPlugin
 Compiling to make sure install is clean
 Skipping foo.ui (unchanged)
 Compiled 0 UI files
@@ -296,7 +296,7 @@ Copying foo.py
 Copying resources_rc.py
 Copying icon.png
 Copying metadata.txt
-Copying help/build/html to /Users/gsherman/.qgis2/python/plugins/TestPlugin/help
+Copying help/build/html to /Users/gsherman/~/(UserProfile)/python/plugins/TestPlugin/help
 ```
 
 ## What's Missing

--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -20,6 +20,7 @@
 __author__ = 'gsherman'
 
 import os
+from platform import platform
 import sys
 import subprocess
 import shutil
@@ -219,7 +220,7 @@ def install_files(plugin_dir, cfg):
 
 
 def clean_deployment(ask_first=True, config='pb_tool.cfg', plugin_dir=None):
-    """ Remove the deployed plugin from the .qgis2/python/plugins directory
+    """ Remove the deployed plugin from the ~/(UserProfile)/python/plugins directory
     """
     if not plugin_dir:
         name = get_config(config).get('plugin', 'name')
@@ -266,7 +267,7 @@ def clean_docs():
               default='pb_tool.cfg',
               help='Name of the config file to use if other than pb_tool.cfg')
 def dclean(config):
-    """ Remove the deployed plugin from the .qgis2/python/plugins directory
+    """ Remove the deployed plugin from the ~/(UserProfile)/python/plugins directory
     """
     clean_deployment(True, config)
 
@@ -753,8 +754,15 @@ def copy(source, destination):
 
 def get_plugin_directory():
     home = os.path.expanduser('~')
-    qgis2 = os.path.join('.qgis2', 'python', 'plugins')
-    return os.path.join(home, qgis2)
+    platform = sys.platform
+    if platform == 'win32':
+        userprofiles = os.path.join('AppData', 'Roaming')
+    elif platform == 'linux':
+        userprofiles = os.path.join('.local', 'share')
+    elif platform == 'mac':
+        userprofiles = os.path.join('Libary', 'Application Support')
+    qgis3 = os.path.join(home, userprofiles, 'QGIS', 'QGIS3', 'profiles', 'python', 'plugins')
+    return os.path.join(home, qgis3)
 
 
 def config_template():
@@ -770,7 +778,7 @@ def config_template():
 
 [plugin]
 # Name of the plugin. This is the name of the directory that will
-# be created in .qgis2/python/plugins
+# be created in ~/(UserProfile)/python/plugins
 name: $Name
 
 # Full path to where you want your plugin directory copied. If empty,

--- a/pb_tool/templates/pb_tool.tmpl
+++ b/pb_tool/templates/pb_tool.tmpl
@@ -37,7 +37,7 @@
 
 [plugin]
 # Name of the plugin. This is the name of the directory that will
-# be created in .qgis2/python/plugins
+# be created in ~/(UserProfile)/python/plugins
 name: ${TemplateModuleName}
 
 [files]

--- a/test_plugin/Makefile
+++ b/test_plugin/Makefile
@@ -67,7 +67,7 @@ PLUGIN_UPLOAD = $(c)/plugin_upload.py
 
 RESOURCE_SRC=$(shell grep '^ *<file' resources.qrc | sed 's@</file>@@g;s/.*>//g' | tr '\n' ' ')
 
-QGISDIR=.qgis2
+QGISDIR=<UserProfiles>/QGIS/QGIS3/profiles/default
 
 default: compile
 
@@ -100,7 +100,7 @@ test: compile transcompile
 deploy: compile doc transcompile
 	@echo
 	@echo "------------------------------------------"
-	@echo "Deploying plugin to your .qgis2 directory."
+	@echo "Deploying plugin to your ~/<UserProfiles>/QGIS/QGIS3/profiles/default/python/plugins directory."
 	@echo "------------------------------------------"
 	# The deploy  target only works on unix like operating system where
 	# the Python plugin directory is located at:

--- a/test_plugin/README.html
+++ b/test_plugin/README.html
@@ -9,7 +9,7 @@ Your plugin <b>TestPlugin</b> was created in:<br>
 &nbsp;&nbsp;<b>/Users/gsherman/development/qgis_plugins/TestPlugin</b>
 <p>
 Your QGIS plugin directory is located at:<br>
-&nbsp;&nbsp;<b>/Users/gsherman/.qgis2/python/plugins</b>
+&nbsp;&nbsp;<b>/Users/gsherman/~/(UserProfile)/python/plugins</b>
 <p>
 <h3>What's Next</h3>
 <ol>

--- a/test_plugin/README.txt
+++ b/test_plugin/README.txt
@@ -4,7 +4,7 @@ Your plugin TestPlugin was created in:
     /Users/gsherman/development/qgis_plugins/TestPlugin
 
 Your QGIS plugin directory is located at:
-    /Users/gsherman/.qgis2/python/plugins
+    /Users/gsherman/~/(UserProfile)/python/plugins
 
 What's Next:
 

--- a/test_plugin/pb_tool.cfg
+++ b/test_plugin/pb_tool.cfg
@@ -37,7 +37,7 @@
 
 [plugin]
 # Name of the plugin. This is the name of the directory that will
-# be created in .qgis2/python/plugins
+# be created in ~/(UserProfile)/python/plugins
 name: TestPlugin
 
 [files]


### PR DESCRIPTION
Since the address of qgis3 plugins is different from qgis2, change the default path to '~/<UserProFiles>/QGIS/QGIS3/profiles/default/python/plugins'