### PR TITLE
Support installing modules in subdirectories.

### DIFF
--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -278,10 +278,7 @@ def clean_docs():
     if proceed:
         if os.path.exists('help'):
             click.echo('Removing built HTML from the help documentation')
-            if sys.platform == 'win32':
-                makeprg = 'make.bat'
-            else:
-                makeprg = 'make'
+            makeprg = find_make()
             cwd = os.getcwd()
             os.chdir('help')
             subprocess.check_call([makeprg, 'clean'])
@@ -344,10 +341,7 @@ def build_docs():
     """ Build the docs using sphinx"""
     if os.path.exists('help'):
         click.echo('Building the help documentation')
-        if sys.platform == 'win32':
-            makeprg = 'make.bat'
-        else:
-            makeprg = 'make'
+        makeprg = find_make()
         cwd = os.getcwd()
         os.chdir('help')
         subprocess.check_call([makeprg, 'html'])
@@ -1144,6 +1138,17 @@ def file_changed(infile, outfile):
         return infile_s.st_mtime > outfile_s.st_mtime
     except:
         return True
+
+
+def find_make():
+    makeprg = shutil.which('make')
+    if makeprg is None:
+        click.secho('Error: can not find "make" program.  Install it and/or update the PATH environment variable.',
+                    fg='red')
+        if os.name == 'nt':
+            click.secho('On windows, you can install GnuWin32 Make.', fg='red')
+        sys.exit(1)
+    return makeprg
 
 
 def find_zip():

--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -181,7 +181,9 @@ def install_files(plugin_dir, cfg):
     for file in install_files:
         click.secho("Copying {0}".format(file), fg='magenta', nl=False)
         try:
-            shutil.copy(file, os.path.join(plugin_dir, file))
+            target = os.path.join(plugin_dir, file)
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            shutil.copy(file, target)
             print("")
         except Exception as oops:
             errors.append(

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Topic :: Scientific/Engineering :: GIS'],
     keywords='QGIS PyQGIS',
     platforms=['Linux', 'Windows', 'OS X'],
-    packages=find_packages(),
+    packages=['pb_tool'],
     package_data={'pb_tool': ['templates/*.tmpl', 'templates/icon.png',
                               'templates/dialog/*.*', 'templates/minimal/*.*']},
     include_package_data=True,


### PR DESCRIPTION
I've added a call to 'os.makedirs()' to create subdirectories of the plugin install directory if needed.

Also, I noticed that the version available on PyPI contains a few updates w.r.t. the version here on Github.