### PR TITLE
Use error exit code if files could not be installed

### DIFF
--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -238,6 +238,7 @@ def install_files(plugin_dir, cfg):
             "them from the config. To ensure proper deployment, make sure your\n"
             "UI and resource files are compiled. Using dclean to delete the\n"
             "plugin before deploying may also help.")
+        sys.exit(1)
 
 
 def clean_deployment(ask_first=True, config='pb_tool.cfg', plugin_dir=None):


### PR DESCRIPTION
This enables use in scripts with proper error handling: `pbt deploy -y && echo "success" || echo "fail"`

Also, when used with the Plugin Reloader plugin, it won't silently swallow errors on deployment anymore but show a yellow error bar instead.