### PR TITLE
Fix Issue #39: plugin_path in config file is ignored

### DIFF
--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -139,7 +139,11 @@ def deploy_files(config_file, plugin_path, confirm=True, quick=False, build_help
         click.secho("Configuration file {0} is missing.".format(config_file), fg="red")
     else:
         cfg = get_config(config_file)
-        if not plugin_path:
+
+        plugin_path = cfg.get('plugin', 'plugin_path', fallback=None)
+        if plugin_path:
+            click.secho("Using plugin directory from pb_tool.cfg", fg='green')
+        else:
             plugin_path = get_plugin_directory()
             if not plugin_path:
                 click.secho("Unable to determine where to deploy your plugin", fg="red")

--- a/pb_tool/pb_tool.py
+++ b/pb_tool/pb_tool.py
@@ -140,10 +140,11 @@ def deploy_files(config_file, plugin_path, confirm=True, quick=False, build_help
     else:
         cfg = get_config(config_file)
 
-        plugin_path = cfg.get('plugin', 'plugin_path', fallback=None)
-        if plugin_path:
+        if not plugin_path:
+            plugin_path = cfg.get('plugin', 'plugin_path', fallback=None)
             click.secho("Using plugin directory from pb_tool.cfg", fg='green')
-        else:
+
+        if not plugin_path:
             plugin_path = get_plugin_directory()
             if not plugin_path:
                 click.secho("Unable to determine where to deploy your plugin", fg="red")


### PR DESCRIPTION
# Fix: Respect plugin_path from pb_tool.cfg

## Summary
This PR fixes an issue where the `plugin_path` setting defined in `pb_tool.cfg` was being ignored during deployment. As a result, plugins were always deployed to the default QGIS plugin directory, regardless of the configured value.

## Changes
- Ensure that `plugin_path` from `pb_tool.cfg` is properly read and applied during deployment.
- Restore expected behavior when no `--plugin_path` CLI argument is provided.
- Preserve precedence of the command-line option (`--plugin_path`) over the configuration file.

## Behavior After Fix
✅ `plugin_path` in `pb_tool.cfg` is now respected.
✅ `--plugin_path` continues to override the config value when explicitly provided.

## Related Issue
Fixes #39

## Notes
This restores the documented behavior and aligns configuration-based deployment with user expectations.